### PR TITLE
Add request delay option to avoid rate limits

### DIFF
--- a/cyborgfuzz.sh
+++ b/cyborgfuzz.sh
@@ -22,17 +22,21 @@ get_next_output_name() {
   echo "output${i}.txt"
 }
 
-while getopts l:w: flag; do
+while getopts l:w:d: flag; do
   case "${flag}" in
     l) input_file=${OPTARG};;
     w) wordlist=${OPTARG};;
+    d) delay=${OPTARG};;   # Optional delay parameter
   esac
 done
 
 if [[ -z "$input_file" || -z "$wordlist" ]]; then
-  echo "Usage: ./cyborgfuzz.sh -l livesubs.txt -w wordlist.txt"
+  echo "Usage: ./cyborgfuzz.sh -l livesubs.txt -w wordlist.txt [-d delay_in_seconds]"
   exit 1
 fi
+
+# Default delay to 0 if not set
+delay=${delay:-0}
 
 print_banner
 
@@ -40,7 +44,7 @@ output_file=$(get_next_output_name)
 echo "[*] Output will be saved to: $output_file"
 echo ""
 
-echo "[*] Starting fuzzing..."
+echo "[*] Starting fuzzing with delay of $delay seconds between requests..."
 while IFS= read -r domain; do
   while IFS= read -r path; do
     full_url="${domain%/}/${path}"
@@ -49,6 +53,10 @@ while IFS= read -r domain; do
     if [[ "$code" == "200" || "$code" == "403" || "$code" == "401" ]]; then
       echo "$full_url" >> "$output_file"
     fi
+    
+    # Add delay to avoid overwhelming the target
+    sleep "$delay"
+    
   done < "$wordlist"
 done < "$input_file"
 


### PR DESCRIPTION
Implemented optional -d flag to specify delay (including decimals) between requests, reducing target overload and helping bypass rate limits during fuzzing.